### PR TITLE
Triggers CI on pull request events

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,9 @@
 name: CI/CD Pipeline
 
 on:
-  push:
-    branches: [ develop, main ]
   pull_request:
     branches: [ develop, main ]
+    types: [ opened, synchronize, reopened ]
 
 env:
   GO_VERSION: '1.21'


### PR DESCRIPTION
Updates the CI workflow to trigger on pull request events, specifically when a pull request is opened, synchronized, or reopened.

Removes push event triggers as they are redundant with pull requests.

## Description
Update CI/CD workflow triggers